### PR TITLE
Upgrade INCURSION_ATOMIC_INTEGRITY_SCHEMA from v5.0 to v5.1 (additive extension)

### DIFF
--- a/INCURSION_ATOMIC_INTEGRITY_SCHEMA.yaml
+++ b/INCURSION_ATOMIC_INTEGRITY_SCHEMA.yaml
@@ -1,4 +1,4 @@
-schema_version: "5.0.0"
+schema_version: "5.1.0"
 authority: "EXTERNAL_IMMUTABLE"
 hash_algorithm: "SHA-256"
 
@@ -79,6 +79,16 @@ engineering_invariants:
   DETERMINISTIC:
     rule: "Same seed + same input → same output, always"
     enforcement: "Canonical JSON serialization & deterministic hash"
+  FRACTAL:
+    rule: "Sub-asset hash chains recursively; Hash(children) = parent hash"
+    enforcement: "Merkle tree verification at every level"
+    oe_reference: "ontology/falsification_tests.json → F_FRACTALS_001"
+    ontology_domain: "D_FRACTALS"
+  PEANO_ARITHMETIC:
+    rule: "Event sequencing via canonical Peano successor S(n); no gate may be skipped"
+    enforcement: "Sequential gate enforcement; S(0)=1, S(n)=n+1, no jumps"
+    oe_reference: "SOP_AI_HANDSHAKE.md → Section VI"
+    ontology_domain: "D_AXIOMS"
 
 anti_nominalism_clauses:
   clause_001: "No label without hashed referent; every artifact corresponds to a covenant principle."
@@ -95,10 +105,12 @@ modules:
       MissionStateHash: { type: SHA256 }
       DeterministicSeed: { type: int64 }
       TemporalSync: { type: "{WorldTime: float, WeatherIntensity: float, TemporalSyncHash: SHA256}" }
+      QoLFlags: { type: "{AccessibilityMode: bool, HintLevel: int}" }
     invariants:
       - "MissionStateHash = SHA256(canonical_json(ObjectiveList))"
       - "DeterministicSeed immutable after mission start"
-    hello_world: "Seed=1, verify 1 objective at [0,0,0], hash matches"
+      - "AccessibilityMode enforced across all objectives"
+    hello_world: "Seed=1, verify 1 objective at [0,0,0], hash matches + QoL flags present"
     oe_reference: "generators/skate4_multiplayer_fractal_dataset.py → generate_node_id()"
     slc_reference: "covenant.yaml → root.merkle_root"
 
@@ -108,9 +120,11 @@ modules:
       InventoryState: { type: "array<{ItemID: UUID, Quantity: int, AttachmentHash: SHA256}>" }
       UIStateHash: { type: SHA256 }
       LastActionHash: { type: SHA256 }
+      AccessibilityFlags: { type: "{ColorBlind: bool, LargeFont: bool}" }
     invariants:
       - "UIStateHash = SHA256(canonical_json(InventoryState))"
       - "LastActionHash chains append-only"
+      - "AccessibilityFlags enforced at render"
     hello_world: "Create empty inventory, verify UIStateHash = SHA256('[]')"
     oe_reference: "tools/state_witness/generate_feed_entry.py → build_feed_entry()"
     slc_reference: "src/infrastructure.py → ArtifactRegistry"
@@ -122,9 +136,12 @@ modules:
       PathingHash: { type: SHA256 }
       DecisionStepHash: { type: SHA256 }
       PerceptionLogic: { type: "{EstimatedTargetVector: vec3, CollisionLayerCount: int, ValidationHash: SHA256}" }
+      PredictiveSimulation: { type: "{FutureStates: array<SHA256>, DeterministicSeed: int64}" }
     invariants:
       - "PathingHash = SHA256(canonical_json(path_nodes))"
       - "DecisionStepHash chains sequentially"
+      - "PredictiveSimulation deterministic per seed"
+      - "Cross-module MissionStateHash sync"
     hello_world: "Spawn AI at [0,0,0], verify PathingHash for null path"
     oe_reference: "generators/skate4_multiplayer_fractal_dataset.py → compute_content_hash()"
     slc_reference: "src/operational_modes.py → POPPERIAN.is_allowed()"
@@ -138,9 +155,11 @@ modules:
       ActionInterruptible: { type: bool }
       TransitionHash: { type: SHA256 }
       ActiveAnimationLock: { type: bool }
+      ResolvedMechanics: { type: "{RecoilPattern: vec3, HitDetection: map<TargetID, bool>}" }
     invariants:
       - "TransitionHash = SHA256(PreviousAction + CurrentAction)"
       - "If ActiveAnimationLock=true, ActionInterruptible=false"
+      - "HitDetection deterministic per frame"
     hello_world: "Set weapon to Idle, verify TransitionHash for null→Idle"
     oe_reference: "toolkit/oe/boundary_enforcer.py → @validate_input_schema"
     slc_reference: "src/operational_modes.py → OperationalMode.is_allowed()"
@@ -154,9 +173,11 @@ modules:
       WorldTime: { type: "float(0-24.0)" }
       WeatherIntensity: { type: float }
       TemporalSyncHash: { type: SHA256 }
+      DAGDependencies: { type: "array<{ParentID: UUID, ChildID: UUID, Hash: SHA256}>" }
     invariants:
       - "TemporalSyncHash = SHA256(WorldTime + WeatherIntensity)"
       - "CollisionMeshHash immutable per map version"
+      - "DAGDependencies acyclic, hash chain validated"
     hello_world: "Load empty map, verify CollisionMeshHash + NavMeshHash"
     oe_reference: "topology/graph_schema.yaml → nodes + edges + zones"
     slc_reference: "topology/graph_schema.yaml → graph_structure"
@@ -295,6 +316,10 @@ cross_module_invariants:
     name: "POPPERIAN_FALSIFIABILITY"
     rule: "Every module has hello-world test that can fail"
     verification: "HelloWorldCheck fields on every module"
+  - id: "INV-GLOBAL-006"
+    name: "DAG_CONSISTENCY"
+    rule: "All MapManager DAGDependencies remain acyclic across operations"
+    verification: "verify_dag_acyclic() from generators/skate4_multiplayer_fractal_dataset.py"
 
 topology_axes:
   - id: AXIS_1
@@ -619,7 +644,7 @@ ai_instructions:
         - MEMORY.md: <yes/no — note any concerns>
         - STATE.md: <current phase, e.g. COMPILATION MODE>
         - Latest handoff: <date of most recent HANDOFF entry, or "none">
-        - Schema version: 5.0.0
+        - Schema version: 5.1.0
         - Modules verified: 13/13
         - HelloWorld checks: ALL PASS
         - Hash chain: INTACT

--- a/tests/test_incursion_atomic_integrity_schema.py
+++ b/tests/test_incursion_atomic_integrity_schema.py
@@ -15,7 +15,7 @@ def schema():
 
 
 def test_top_level_metadata(schema):
-    assert schema["schema_version"] == "5.0.0"
+    assert schema["schema_version"] == "5.1.0"
     assert schema["authority"] == "EXTERNAL_IMMUTABLE"
     assert schema["hash_algorithm"] == "SHA-256"
 
@@ -102,13 +102,14 @@ def test_logger_module(schema):
 
 def test_cross_module_invariants(schema):
     cmi = schema["cross_module_invariants"]
-    assert len(cmi) == 5
+    assert len(cmi) == 6
     names = [entry["name"] for entry in cmi]
     assert "HASH_CHAIN_INTEGRITY" in names
     assert "TEMPORAL_SYNC" in names
     assert "DETERMINISTIC_REPLAY" in names
     assert "COOP_CONSISTENCY" in names
     assert "POPPERIAN_FALSIFIABILITY" in names
+    assert "DAG_CONSISTENCY" in names
 
 
 def test_topology_axes(schema):
@@ -221,3 +222,40 @@ def test_philosophy_domain_falsifiability(schema):
 def test_logger_append_only_invariant(schema):
     logger = schema["modules"]["Logger"]
     assert any("Append-only" in inv for inv in logger["invariants"])
+
+
+def test_fractal_and_peano_invariants(schema):
+    invariants = schema["engineering_invariants"]
+    assert "FRACTAL" in invariants
+    assert "PEANO_ARITHMETIC" in invariants
+    assert "Merkle" in invariants["FRACTAL"]["enforcement"] or "recursive" in invariants["FRACTAL"]["rule"]
+    assert "S(n)" in invariants["PEANO_ARITHMETIC"]["rule"] or "Peano" in invariants["PEANO_ARITHMETIC"]["rule"]
+
+
+def test_qol_and_accessibility_fields(schema):
+    modules = schema["modules"]
+    assert "QoLFlags" in modules["MissionManager"]["fields"]
+    assert "AccessibilityFlags" in modules["InventoryUI"]["fields"]
+
+
+def test_predictive_simulation_field(schema):
+    ai = schema["modules"]["AIController"]
+    assert "PredictiveSimulation" in ai["fields"]
+
+
+def test_resolved_mechanics_field(schema):
+    weapon = schema["modules"]["WeaponSystem"]
+    assert "ResolvedMechanics" in weapon["fields"]
+
+
+def test_dag_dependencies_field(schema):
+    map_mgr = schema["modules"]["MapManager"]
+    assert "DAGDependencies" in map_mgr["fields"]
+    assert any("acyclic" in inv for inv in map_mgr["invariants"])
+
+
+def test_dag_consistency_cross_module_invariant(schema):
+    cmi = schema["cross_module_invariants"]
+    assert len(cmi) == 6  # was 5, now 6
+    names = [entry["name"] for entry in cmi]
+    assert "DAG_CONSISTENCY" in names


### PR DESCRIPTION
## Summary

Additive extension of `INCURSION_ATOMIC_INTEGRITY_SCHEMA.yaml` from v5.0 to v5.1. No existing v5.0 content was removed or restructured — only new sections/fields were appended and version references bumped.

**Schema changes:**
- `schema_version` bumped to `"5.1.0"`
- 2 new engineering invariants: `FRACTAL` (Merkle tree recursive hashing) and `PEANO_ARITHMETIC` (sequential gate enforcement)
- New fields added to 5 modules: `QoLFlags` (MissionManager), `AccessibilityFlags` (InventoryUI), `PredictiveSimulation` (AIController), `ResolvedMechanics` (WeaponSystem), `DAGDependencies` (MapManager)
- Corresponding invariants added to each module
- New cross-module invariant `INV-GLOBAL-006 DAG_CONSISTENCY`
- `acknowledgment_format` version reference updated to 5.1.0

**Test changes:**
- Version assertion updated from 5.0.0 → 5.1.0
- `test_cross_module_invariants` updated to expect 6 entries (was 5)
- 6 new test functions covering all added fields and invariants

All 24 tests pass locally.

## Review & Testing Checklist for Human

- [ ] Verify no existing v5.0 content was accidentally removed — diff should show only additions and the three explicitly requested line modifications (version, hello_world text, acknowledgment_format)
- [ ] Confirm new fields are placed after the correct predecessor fields in each module (e.g., `QoLFlags` after `TemporalSync`, `DAGDependencies` after `TemporalSyncHash`)
- [ ] Verify `oe_reference` paths in FRACTAL (`ontology/falsification_tests.json`) and PEANO_ARITHMETIC (`SOP_AI_HANDSHAKE.md → Section VI`) point to real or intended files
- [ ] Run `python -m pytest tests/test_incursion_atomic_integrity_schema.py -v` to confirm all 24 tests pass

### Notes
- MissionManager `hello_world` was modified (not purely additive) per the request — changed from `"hash matches"` to `"hash matches + QoL flags present"`.
- `test_dag_consistency_cross_module_invariant` partially overlaps with the updated `test_cross_module_invariants` (both assert `len == 6` and check for `DAG_CONSISTENCY`). This is intentional per the spec but could be deduplicated later if desired.

Link to Devin session: https://app.devin.ai/sessions/e6afafc49e594bacaf9b2ff753794e0b
Requested by: @aidoruao
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aidoruao/orthogonal-engineering/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
